### PR TITLE
fix: update condition for blank tree fields in pricing rule

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -206,6 +206,56 @@ class TestPricingRule(IntegrationTestCase):
 		details = get_item_details(args)
 		self.assertEqual(details.get("discount_percentage"), 10)
 
+	def test_unset_group_condition(self):
+		"""
+		If args are not set for group condition, then pricing rule should not be applied.
+		"""
+		from erpnext.stock.get_item_details import get_item_details
+
+		test_record = {
+			"doctype": "Pricing Rule",
+			"title": "_Test Pricing Rule",
+			"apply_on": "Item Code",
+			"items": [{"item_code": "_Test Item"}],
+			"currency": "USD",
+			"selling": 1,
+			"rate_or_discount": "Discount Percentage",
+			"rate": 0,
+			"discount_percentage": 10,
+			"applicable_for": "Territory",
+			"territory": "All Territories",
+			"company": "_Test Company",
+		}
+		frappe.get_doc(test_record.copy()).insert()
+		args = frappe._dict(
+			{
+				"item_code": "_Test Item",
+				"company": "_Test Company",
+				"price_list": "_Test Price List",
+				"currency": "_Test Currency",
+				"doctype": "Sales Order",
+				"conversion_rate": 1,
+				"price_list_currency": "_Test Currency",
+				"plc_conversion_rate": 1,
+				"order_type": "Sales",
+				"customer": "_Test Customer",
+				"name": None,
+			}
+		)
+
+		# without territory in customer
+		customer = frappe.get_doc("Customer", "_Test Customer")
+		territory = customer.territory
+
+		customer.territory = None
+		customer.save()
+
+		details = get_item_details(args)
+		self.assertEqual(details.get("discount_percentage"), 0)
+
+		customer.territory = territory
+		customer.save()
+
 	def test_pricing_rule_for_variants(self):
 		from erpnext.stock.get_item_details import get_item_details
 

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -223,6 +223,10 @@ def _get_tree_conditions(args, parenttype, table, allow_blank=True):
 			)
 
 			frappe.flags.tree_conditions[key] = condition
+
+	elif allow_blank:
+		condition = f"ifnull({table}.{field}, '') = ''"
+
 	return condition
 
 


### PR DESCRIPTION
Issue: Conditions are only applied if the field is set for the Group Doctypes in pricing rule,

Steps to replicate:

    Create a customer without the territory
    Create a pricing rule for a customer with applicable_for a Territory.
    Create a sales invoice and add the item.

Pricing Rule will be applied even though the pricing rule is applicable only for the specified territory.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/40338


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify that pricing rules based on group conditions (such as Territory) are not applied when the relevant condition is unset.
* **Bug Fixes**
  * Improved handling of missing group condition fields to ensure that pricing rules correctly filter for blank or null values when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->